### PR TITLE
Update ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = ./hosts
+inventory = ./hosts
 host_key_checking = False
 retry_files_save_path = retry-files
 log_path = ./ansible.log


### PR DESCRIPTION
Use of "inventory" directive instead of deprecated "hosts", for better support in new Ansible versions