### PR TITLE
Update create.yml

### DIFF
--- a/roles/kolla_hosts/tasks/create.yml
+++ b/roles/kolla_hosts/tasks/create.yml
@@ -26,7 +26,7 @@
 - name: Update docker BIP
   become: True
   lineinfile:
-    path: /usr/lib/systemd/system/docker.service
+    destfile: /usr/lib/systemd/system/docker.service
     regexp: "ExecStart=/usr/bin/dockerd"
     line: "ExecStart=/usr/bin/dockerd --bip=172.26.0.1/16"
 


### PR DESCRIPTION
Use of "destfile" instead of "path" when specifiying lineinfile task, for Ansible backward compatibility.
Before 2.3 this option was only usable as  dest ,  destfile  and  name.
Cheers